### PR TITLE
Add class name rule

### DIFF
--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -2,7 +2,7 @@
 
 ret=0;
 for path in `find test -name tslint.json`; do
-    tslint -r ./build/rules/ --test $path/..
+    ./node_modules/.bin/tslint -r ./build/rules/ --test $path/..
     val=$?
     if [ "$val" -ne "0" ]; then
         ret=$val

--- a/src/rules/blueprintClassNameRule.ts
+++ b/src/rules/blueprintClassNameRule.ts
@@ -17,6 +17,7 @@
 
 import * as Lint from "tslint";
 import * as ts from "typescript";
+import { nodeIsKind } from "../guards";
 
 export class Rule extends Lint.Rules.AbstractRule {
     /* tslint:disable:object-literal-sort-keys */
@@ -45,8 +46,11 @@ function walk(ctx: Lint.WalkContext<void>) {
     return ts.forEachChild(ctx.sourceFile, callback);
 
     function callback(node: ts.Node): void {
-        if (node.kind === ts.SyntaxKind.StringLiteral && (node as ts.StringLiteral).text.startsWith("pt-")) {
-            return ctx.addFailureAtNode(node, Rule.FAILURE_STRING);
+        if (nodeIsKind(node, ts.SyntaxKind.StringLiteral)) {
+            const { text } = (node as ts.StringLiteral);
+            if ((text !== "pt-" && text.startsWith("pt-")) || (text !== ".pt-" && text.startsWith(".pt-"))) {
+                return ctx.addFailureAtNode(node, Rule.FAILURE_STRING);
+            }
         }
 
         return ts.forEachChild(node, callback);

--- a/src/rules/blueprintClassNameRule.ts
+++ b/src/rules/blueprintClassNameRule.ts
@@ -45,7 +45,6 @@ function walk(ctx: Lint.WalkContext<void>) {
     return ts.forEachChild(ctx.sourceFile, callback);
 
     function callback(node: ts.Node): void {
-        // TODO: check if in JSX and add an option?
         if (node.kind === ts.SyntaxKind.StringLiteral && (node as ts.StringLiteral).text.startsWith("pt-")) {
             return ctx.addFailureAtNode(node, Rule.FAILURE_STRING);
         }

--- a/src/rules/blueprintClassNameRule.ts
+++ b/src/rules/blueprintClassNameRule.ts
@@ -19,7 +19,22 @@ import * as Lint from "tslint";
 import * as ts from "typescript";
 
 export class Rule extends Lint.Rules.AbstractRule {
-    public static FAILURE_STRING = "blueprint class name as string forbidden, use Classes.* instead";
+    /* tslint:disable:object-literal-sort-keys */
+    public static metadata: Lint.IRuleMetadata = {
+        ruleName: "blueprint-class-name",
+        description: "Checks for Blueprint class names that are expressed as string literals",
+        descriptionDetails: Lint.Utils.dedent
+            `Using string literals instead of a constant from Classes.* exported by Blueprint
+            is prone to typos and prevents compile-time validation of class existence.`,
+        options: null,
+        optionsDescription: "",
+        optionExamples: ["true"],
+        type: "maintainability",
+        typescriptOnly: false,
+    };
+    /* tslint:enable:object-literal-sort-keys */
+
+    public static FAILURE_STRING = "Use a constant from Classes.* instead of a string literal class name";
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
         return this.applyWithFunction(sourceFile, walk);
@@ -31,8 +46,7 @@ function walk(ctx: Lint.WalkContext<void>) {
 
     function callback(node: ts.Node): void {
         // TODO: check if in JSX and add an option?
-        if (node.kind === ts.SyntaxKind.StringLiteral && (node as ts.StringLiteral).getFullText().startsWith("pt-")) {
-            // TODO: add a fixer?
+        if (node.kind === ts.SyntaxKind.StringLiteral && (node as ts.StringLiteral).text.startsWith("pt-")) {
             return ctx.addFailureAtNode(node, Rule.FAILURE_STRING);
         }
 

--- a/src/rules/blueprintClassNameRule.ts
+++ b/src/rules/blueprintClassNameRule.ts
@@ -18,25 +18,22 @@
 import * as Lint from "tslint";
 import * as ts from "typescript";
 
-// tslint:disable max-classes-per-file
-
 export class Rule extends Lint.Rules.AbstractRule {
     public static FAILURE_STRING = "blueprint class name as string forbidden, use Classes.* instead";
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
-        return this.applyWithWalker(new NoStringClassNameWalker(sourceFile, this.getOptions()));
+        return this.applyWithFunction(sourceFile, walk);
     }
 }
 
-class NoStringClassNameWalker extends Lint.RuleWalker {
-    protected visitStringLiteral(node: ts.StringLiteral) {
-        console.log(node.getText());
-        if (node.getText().startsWith("pt-")) {
-            console.log(node.getLastToken());
-            // TODO: a fixer?
-            this.addFailureAtNode(node, Rule.FAILURE_STRING);
+function walk(ctx: Lint.WalkContext<void>) {
+    return ts.forEachChild(ctx.sourceFile, callback);
+
+    function callback(node: ts.Node): void {
+        if (node.kind === ts.SyntaxKind.StringLiteral && (node as ts.StringLiteral).getFullText().startsWith("pt-")) {
+            return ctx.addFailureAtNode(node, Rule.FAILURE_STRING);
         }
 
-        super.visitStringLiteral(node);
+        return ts.forEachChild(node, callback);
     }
 }

--- a/src/rules/blueprintClassNameRule.ts
+++ b/src/rules/blueprintClassNameRule.ts
@@ -18,6 +18,8 @@
 import * as Lint from "tslint";
 import * as ts from "typescript";
 
+// tslint:disable max-classes-per-file
+
 export class Rule extends Lint.Rules.AbstractRule {
     public static FAILURE_STRING = "blueprint class name as string forbidden, use Classes.* instead";
 
@@ -28,6 +30,7 @@ export class Rule extends Lint.Rules.AbstractRule {
 
 class NoStringClassNameWalker extends Lint.RuleWalker {
     protected visitStringLiteral(node: ts.StringLiteral) {
+        console.log(node.getText());
         if (node.getText().startsWith("pt-")) {
             console.log(node.getLastToken());
             // TODO: a fixer?

--- a/src/rules/blueprintClassNameRule.ts
+++ b/src/rules/blueprintClassNameRule.ts
@@ -30,7 +30,9 @@ function walk(ctx: Lint.WalkContext<void>) {
     return ts.forEachChild(ctx.sourceFile, callback);
 
     function callback(node: ts.Node): void {
+        // TODO: check if in JSX and add an option?
         if (node.kind === ts.SyntaxKind.StringLiteral && (node as ts.StringLiteral).getFullText().startsWith("pt-")) {
+            // TODO: add a fixer?
             return ctx.addFailureAtNode(node, Rule.FAILURE_STRING);
         }
 

--- a/src/rules/blueprintClassNameRule.ts
+++ b/src/rules/blueprintClassNameRule.ts
@@ -25,8 +25,8 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: "blueprint-class-name",
         description: "Checks for Blueprint class names that are expressed as string literals",
         descriptionDetails: Lint.Utils.dedent
-            `Using string literals instead of a constant from Classes.* exported by Blueprint
-            is prone to typos and prevents compile-time validation of class existence.`,
+            `Using string literals instead of a constant from @blueprintjs/core's Classes or IconClasses
+            is prone to typos and prevents compile-time validation of the CSS class's existence.`,
         options: null,
         optionsDescription: "",
         optionExamples: ["true"],
@@ -35,7 +35,7 @@ export class Rule extends Lint.Rules.AbstractRule {
     };
     /* tslint:enable:object-literal-sort-keys */
 
-    public static FAILURE_STRING = "Use a constant from Classes.* instead of a string literal class name";
+    public static FAILURE_STRING = "Use a constant from Classes or IconClasses instead of a string literal";
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
         return this.applyWithFunction(sourceFile, walk);

--- a/src/rules/noStringClassNamesRule.ts
+++ b/src/rules/noStringClassNamesRule.ts
@@ -1,0 +1,39 @@
+/**
+ * @license
+ * Copyright 2017 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as Lint from "tslint";
+import * as ts from "typescript";
+
+export class Rule extends Lint.Rules.AbstractRule {
+    public static FAILURE_STRING = "blueprint class name as string forbidden, use Classes.* instead";
+
+    public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
+        return this.applyWithWalker(new NoStringClassNameWalker(sourceFile, this.getOptions()));
+    }
+}
+
+class NoStringClassNameWalker extends Lint.RuleWalker {
+    protected visitStringLiteral(node: ts.StringLiteral) {
+        if (node.getText().startsWith("pt-")) {
+            console.log(node.getLastToken());
+            // TODO: a fixer?
+            this.addFailureAtNode(node, Rule.FAILURE_STRING);
+        }
+
+        super.visitStringLiteral(node);
+    }
+}

--- a/test/rules/blueprint-class-name/test.tsx.lint
+++ b/test/rules/blueprint-class-name/test.tsx.lint
@@ -1,11 +1,18 @@
 const class = "pt-fill";
-              ~~~~~~~~~    [0]
+              ~~~~~~~~~              [0]
 
 <div className={"pt-fill"} />
-                ~~~~~~~~~  [0]
+                ~~~~~~~~~            [0]
+
+document.querySelector(".pt-button")
+                       ~~~~~~~~~~~~  [0]
 
 <div className={Classes.FILL} />
 
 <div className={"my-class"} />
+
+<div className={"pt"} />
+
+document.querySelector(".pt")
 
 [0]: Use a constant from Classes.* instead of a string literal class name

--- a/test/rules/blueprint-class-name/test.tsx.lint
+++ b/test/rules/blueprint-class-name/test.tsx.lint
@@ -1,0 +1,4 @@
+const class = "pt-fill";
+              ~~~~~~~~~    [0]
+
+[0]: Use a constant from Classes.* instead of a string literal class name

--- a/test/rules/blueprint-class-name/test.tsx.lint
+++ b/test/rules/blueprint-class-name/test.tsx.lint
@@ -1,4 +1,11 @@
 const class = "pt-fill";
               ~~~~~~~~~    [0]
 
+<div className={"pt-fill"} />
+                ~~~~~~~~~  [0]
+
+<div className={Classes.FILL} />
+
+<div className={"my-class"} />
+
 [0]: Use a constant from Classes.* instead of a string literal class name

--- a/test/rules/blueprint-class-name/test.tsx.lint
+++ b/test/rules/blueprint-class-name/test.tsx.lint
@@ -15,4 +15,4 @@ document.querySelector(".pt-button")
 
 document.querySelector(".pt")
 
-[0]: Use a constant from Classes.* instead of a string literal class name
+[0]: Use a constant from Classes or IconClasses instead of a string literal

--- a/test/rules/blueprint-class-name/tslint.json
+++ b/test/rules/blueprint-class-name/tslint.json
@@ -1,0 +1,5 @@
+{
+    "rules": {
+        "blueprint-class-name": true
+    }
+}

--- a/tslint-blueprint.json
+++ b/tslint-blueprint.json
@@ -1,5 +1,6 @@
 {
-    "rulesDirectory": "./rules",
+    "rulesDirectory": "./src/rules",
     "rules": {
+        "no-string-class-names": true
     }
 }

--- a/tslint-blueprint.json
+++ b/tslint-blueprint.json
@@ -1,6 +1,6 @@
 {
-    "rulesDirectory": "./src/rules",
+    "rulesDirectory": "./rules",
     "rules": {
-        "no-string-class-names": true
+        "blueprint-class-name": true
     }
 }


### PR DESCRIPTION
We error on usage of string literal Blueprint class names in order to minimize typos and ensure compile-time correctness of class references.